### PR TITLE
Escape tool escapes new lines as

### DIFF
--- a/src/dev/impl/DevToys/DevToys.csproj
+++ b/src/dev/impl/DevToys/DevToys.csproj
@@ -85,7 +85,10 @@
     <Compile Include="Models\JwtDecoderEncoder\TokenParameters.cs" />
     <Compile Include="Models\JwtDecoderEncoder\TokenResult.cs" />
     <Compile Include="Models\JwtDecoderEncoder\TokenResultErrorEventArgs.cs" />
+    <Compile Include="Models\NewlineEncodingDisplayPair.cs" />
     <Compile Include="Models\NumberBaseDictionary.cs" />
+    <Compile Include="Models\SpecialCharacter.cs" />
+    <Compile Include="Models\SpecialCharacterDefinition.cs" />
     <Compile Include="Models\SqlLanguageDisplayPair.cs" />
     <Compile Include="Models\NoResultFoundMockToolProvider.cs" />
     <Compile Include="Models\Radix.cs" />

--- a/src/dev/impl/DevToys/LanguageManager.cs
+++ b/src/dev/impl/DevToys/LanguageManager.cs
@@ -2604,7 +2604,7 @@ namespace DevToys
         /// Gets the resource SpecialCharacters.
         /// </summary>
         public string SpecialCharacters => _resources.GetString("SpecialCharacters");
-        
+
         /// <summary>
         /// Gets the resource ExcludeCharacters.
         /// </summary>
@@ -3295,6 +3295,11 @@ namespace DevToys
         /// Gets the resource InputTitle.
         /// </summary>
         public string InputTitle => _resources.GetString("InputTitle");
+
+        /// <summary>
+        /// Gets the resource NewlineEncoding.
+        /// </summary>
+        public string NewlineEncoding => _resources.GetString("NewlineEncoding");
     }
 
     public class StringUtilitiesStrings : ObservableObject

--- a/src/dev/impl/DevToys/Models/NewlineEncodingDisplayPair.cs
+++ b/src/dev/impl/DevToys/Models/NewlineEncodingDisplayPair.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace DevToys.Models
+{
+    public sealed class NewlineEncodingDisplayPair : IEquatable<NewlineEncodingDisplayPair>
+    {
+        public static readonly NewlineEncodingDisplayPair Linefeed = new(@"LF (\n) (Linux)", SpecialCharacter.LineFeed);
+        public static readonly NewlineEncodingDisplayPair CarriageReturn = new(@"CR (\r) (Mac)", SpecialCharacter.CarriageReturn);
+        public static readonly NewlineEncodingDisplayPair CarriageReturnLineFeed = new(@"CRLF (\r\n) (Windows)", SpecialCharacter.CarriageReturnLineFeed);
+
+        public string DisplayName { get; }
+
+        public SpecialCharacter Value { get; }
+
+        private NewlineEncodingDisplayPair(string displayName, SpecialCharacter value)
+        {
+            DisplayName = displayName;
+            Value = value;
+        }
+
+        public bool Equals(NewlineEncodingDisplayPair other) => other.Value == Value;
+    }
+}
+
+

--- a/src/dev/impl/DevToys/Models/SpecialCharacter.cs
+++ b/src/dev/impl/DevToys/Models/SpecialCharacter.cs
@@ -1,0 +1,43 @@
+﻿namespace DevToys.Models
+{
+    /// <summary>
+    /// Special characters. Value corresponds to ASCII code. Exceptions with no ASCII representation have a negative value.
+    /// </summary>
+    public enum SpecialCharacter
+    {
+        /// <summary>
+        /// \r\n
+        /// </summary>
+        CarriageReturnLineFeed = -1,
+        /// <summary>
+        /// \b
+        /// </summary>
+        Backspace = 8,
+        /// <summary>
+        /// \t
+        /// </summary>
+        HorizontalTab = 9,
+        /// <summary>
+        /// \n
+        /// </summary>
+        LineFeed = 10,
+        /// <summary>
+        /// \f
+        /// </summary>
+        FormFeed = 12,
+        /// <summary>
+        /// \r
+        /// </summary>
+        CarriageReturn = 13,
+        /// <summary>
+        /// "
+        /// </summary>
+        DoubleQuote = 34,
+        /// <summary>
+        /// \
+        /// </summary>
+        Backslash = 92
+    }
+}
+
+

--- a/src/dev/impl/DevToys/Models/SpecialCharacterDefinition.cs
+++ b/src/dev/impl/DevToys/Models/SpecialCharacterDefinition.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+
+namespace DevToys.Models
+{
+    /// <summary>
+    /// Wrapper for common characters and common operations on them.
+    /// </summary>
+    public sealed class SpecialCharacterDefinition : IEquatable<SpecialCharacterDefinition>
+    {
+        /// <summary>
+        /// Keep a collection of our instances so we can iterate them if needed.
+        /// </summary>
+        private static readonly ICollection<SpecialCharacterDefinition> _definitions =
+            new List<SpecialCharacterDefinition>();
+        public static readonly SpecialCharacterDefinition LineFeed =
+            new SpecialCharacterDefinition(SpecialCharacter.LineFeed, "\n", "\\n");
+        public static readonly SpecialCharacterDefinition CarriageReturn =
+            new SpecialCharacterDefinition(SpecialCharacter.CarriageReturn, "\r", "\\r");
+        public static readonly SpecialCharacterDefinition CarriageReturnLinefeed =
+            new SpecialCharacterDefinition(SpecialCharacter.CarriageReturnLineFeed, "\r\n", "\\r\\n");
+        public static readonly SpecialCharacterDefinition Tab =
+            new SpecialCharacterDefinition(SpecialCharacter.HorizontalTab, "\t", "\\t");
+        public static readonly SpecialCharacterDefinition Backspace =
+            new SpecialCharacterDefinition(SpecialCharacter.Backspace, "\b", "\\b");
+        public static readonly SpecialCharacterDefinition FormFeed =
+            new SpecialCharacterDefinition(SpecialCharacter.FormFeed, "\f", "\\f");
+        public static readonly SpecialCharacterDefinition DoubleQuote =
+            new SpecialCharacterDefinition(SpecialCharacter.DoubleQuote, "\"", "\\\"");
+        public static readonly SpecialCharacterDefinition Backslash =
+            new SpecialCharacterDefinition(SpecialCharacter.Backslash, "\\", "\\\\");
+        private SpecialCharacterDefinition(SpecialCharacter encoding, string value, string escaped)
+        {
+            this.Type = encoding;
+            this.Value = value;
+            this.Escaped = escaped;
+            SpecialCharacterDefinition._definitions.Add(this);
+        }
+        public SpecialCharacter Type { get; private set; }
+        public string Value { get; private set; }
+        public string Escaped { get; private set; }
+
+        public static SpecialCharacterDefinition Parse(string value)
+        {
+            return SpecialCharacterDefinition._definitions.FirstOrDefault(x => x.Value == value);
+        }
+
+        public static SpecialCharacterDefinition Parse(SpecialCharacter value)
+        {
+            return SpecialCharacterDefinition._definitions.FirstOrDefault(x => x.Type == value);
+        }
+        public bool Equals(SpecialCharacterDefinition other) => other.Value == Value;
+
+        public static implicit operator string(SpecialCharacterDefinition d) => d.Value;
+    }
+}
+
+

--- a/src/dev/impl/DevToys/Strings/en-US/StringEscapeUnescape.resw
+++ b/src/dev/impl/DevToys/Strings/en-US/StringEscapeUnescape.resw
@@ -154,4 +154,7 @@
   <data name="InputTitle" xml:space="preserve">
     <value>Input</value>
   </data>
+  <data name="NewlineEncoding" xml:space="preserve">
+    <value>Newline Encoding</value>
+  </data>
 </root>

--- a/src/dev/impl/DevToys/Views/Tools/Text/StringEscapeUnescape/StringEscapeUnescapeToolPage.xaml
+++ b/src/dev/impl/DevToys/Views/Tools/Text/StringEscapeUnescape/StringEscapeUnescapeToolPage.xaml
@@ -25,6 +25,19 @@
             <StackPanel Spacing="4" Grid.Row="0" >
                 <TextBlock Style="{StaticResource SubTitleTextBlock}" Text="{x:Bind ViewModel.Strings.ConfigurationTitle}" />
                 <controls:ExpandableSettingControl
+                    VerticalAlignment="Stretch"
+                    VerticalContentAlignment="Stretch"
+                    Title="{x:Bind ViewModel.Strings.NewlineEncoding}">
+                    <controls:ExpandableSettingControl.Icon>
+                        <FontIcon Glyph="&#xF17E;" />
+                    </controls:ExpandableSettingControl.Icon>
+                    <ComboBox
+                        ItemsSource="{x:Bind ViewModel.NewlineEncodings}"
+                        DisplayMemberPath="DisplayName"
+                        SelectedValue="{x:Bind ViewModel.NewlineEncoding, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                    </ComboBox>
+                </controls:ExpandableSettingControl>
+                <controls:ExpandableSettingControl
                     Grid.Row="1"
                     Title="{x:Bind ViewModel.Strings.ConversionTitle}"
                     Description="{x:Bind ViewModel.Strings.ConversionDescription}">


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Text Escape/Unescape Newline Encoding Options

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] New feature or enhancement
- [x] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently escaping or unescaping newlines in text only handles \r
Issue Number: 468

## What is the new behavior?
Allows the user to choose encoding option for newlines between CRLF (\r\n) (Windows), CR (\r) (Mac) and LF (\n) (Linux)
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds a combox withe the following options in the Text Escape/Unescape UI: CRLF (\r\n) (Windows), CR (\r) (Mac) and LF (\n) (Linux)
- Replaces all newline charcters to the option selected when escaping
- Converts all escaped newline charcters to the option selected

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
before
![image](https://github.com/heribertolugo/DevToys/assets/26213368/25f4ef0b-0f5d-48a1-80f6-1505d28f717c)

after
![image](https://github.com/heribertolugo/DevToys/assets/26213368/c20122b5-2609-482a-9337-c9123f7b090f)


## Quality check

Before creating this PR:

- [x] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [x] Did you verify that the change work in Release build configuration
- [x] Did you verify that all unit tests pass
- [x] If necessary and if possible, did you verify your changes on:
   - [x] Windows
   - [ ] macOS (DevToys 2.0)
   - [ ] Linux (DevToys 2.0)